### PR TITLE
Add static ctor to DispatcherImpl to force late initialization of static UiThread property

### DIFF
--- a/src/Avalonia.Base/Threading/DispatcherImpl.cs
+++ b/src/Avalonia.Base/Threading/DispatcherImpl.cs
@@ -13,6 +13,9 @@ namespace Avalonia.Threading
         public static DispatcherImpl UIThread { get; } =
             new DispatcherImpl(AvaloniaLocator.Current.GetService<IPlatformThreadingInterface>());
 
+        static DispatcherImpl() // do NOT remove: forces late init of UIThread property
+        { }
+
         public DispatcherImpl(IPlatformThreadingInterface platform)
         {
             _platform = platform;

--- a/src/Avalonia.Base/Threading/DispatcherImpl.cs
+++ b/src/Avalonia.Base/Threading/DispatcherImpl.cs
@@ -10,12 +10,6 @@ namespace Avalonia.Threading
         private readonly JobRunner _jobRunner;
         private IPlatformThreadingInterface _platform;
 
-        public static DispatcherImpl UIThread { get; } =
-            new DispatcherImpl(AvaloniaLocator.Current.GetService<IPlatformThreadingInterface>());
-
-        static DispatcherImpl() // do NOT remove: forces late init of UIThread property
-        { }
-
         public DispatcherImpl(IPlatformThreadingInterface platform)
         {
             _platform = platform;

--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -109,7 +109,7 @@ namespace Avalonia.Win32
                 .Bind<IKeyboardDevice>().ToConstant(WindowsKeyboardDevice.Instance)
                 .Bind<IPlatformSettings>().ToConstant(s_instance)
                 .Bind<IPlatformThreadingInterface>().ToConstant(s_instance)
-                .Bind<IDispatcherImpl>().ToConstant(customDispatcher ?? DispatcherImpl.UIThread)
+                .Bind<IDispatcherImpl>().ToConstant(customDispatcher ?? new DispatcherImpl(AvaloniaLocator.Current.GetService<IPlatformThreadingInterface>()))
                 .Bind<IRenderLoop>().ToConstant(new RenderLoop())
                 .Bind<IRenderTimer>().ToConstant(new DefaultRenderTimer(60))
                 .Bind<ISystemDialogImpl>().ToSingleton<SystemDialogImpl>()


### PR DESCRIPTION
[Win32Platform.Initialize](https://github.com/JetBrains/Avalonia/blob/avalonia-win/src/Windows/Avalonia.Win32/Win32Platform.cs#L112) method contains registration of Windows related components. It also includes registration of IDispatcherImpl that uses DispatcherImpl.UIThread as an instance.

[DispatcherImpl.UIThread](https://github.com/JetBrains/Avalonia/blob/avalonia-win/src/Avalonia.Base/Threading/DispatcherImpl.cs#L13) property retrieves IPlatformThreadingInterface by invoke of AvaloniaLocator.

The thing is that DispatcherImpl.UIThread doesn't have static constructor - it leads to the case when static property might be initialized before Win32Platform.Initialize method call. Such premature initialization raises the error because AvaloniaLocator returns null for IPlatformThreadingInterface.

Adding static constructor to DispatcherImpl forces JIT to generate the code that initializes static property at the moment of property invocation.