### PR TITLE
- Initialize textrun object with background brush

### DIFF
--- a/src/Avalonia.Visuals/Media/TextFormatting/TextCharacters.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextCharacters.cs
@@ -63,7 +63,7 @@ namespace Avalonia.Media.TextFormatting
             {
                 return new ShapeableTextCharacters(text.Take(count),
                     new GenericTextRunProperties(currentTypeface, defaultProperties.FontRenderingEmSize,
-                        defaultProperties.TextDecorations, defaultProperties.ForegroundBrush));
+                        defaultProperties.TextDecorations, defaultProperties.ForegroundBrush, defaultProperties.BackgroundBrush));
 
             }
 
@@ -79,7 +79,7 @@ namespace Avalonia.Media.TextFormatting
                 //Fallback found
                 return new ShapeableTextCharacters(text.Take(count),
                     new GenericTextRunProperties(currentTypeface, defaultProperties.FontRenderingEmSize,
-                    defaultProperties.TextDecorations, defaultProperties.ForegroundBrush));
+                    defaultProperties.TextDecorations, defaultProperties.ForegroundBrush, defaultProperties.BackgroundBrush));
             }
 
             // no fallback found
@@ -103,7 +103,7 @@ namespace Avalonia.Media.TextFormatting
 
             return new ShapeableTextCharacters(text.Take(count),
                 new GenericTextRunProperties(currentTypeface, defaultProperties.FontRenderingEmSize,
-                    defaultProperties.TextDecorations, defaultProperties.ForegroundBrush));
+                    defaultProperties.TextDecorations, defaultProperties.ForegroundBrush, defaultProperties.BackgroundBrush));
         }
 
         /// <summary>


### PR DESCRIPTION
## What does the pull request do?
Given PR fixes the issue when text renderer doesn't take into account user provided text run background.


## What is the current behavior?
`TextLayout`'s text renderer doesn't use user provided background color for text rendering.


## What is the updated/expected behavior with this PR?
`TextLayout` renders text with custom background. Custom background has to be initialized with `GenericTextRunProperties`
 and passed to `TextLayout` ctor.

Sample code:

```
var runs = new List<ValueSpan<TextRunProperties>>();
runs.Add(new ValueSpan<TextRunProperties>(
           1, 3, 
           new GenericTextRunProperties(
             typeface, 
             12, 
             foregroundBrush: Brushes.Chocolate, 
             backgroundBrush: Brushes.Yellow)));
var txtLayout = new TextLayout(
  "SampleText", 
  typeface, 10, Brushes.Black, 
  textStyleOverrides: runs);

```